### PR TITLE
Fix typo in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
               /
               <a href="data/CTG++23.bib">bibtex</a>
               <p></p>
-              <p> We leveraged Large Langauge Models (LLMs) and developed a language guided scene-level conditional diffusion model for language-controllable, realistic traffic generation.</p>
+              <p> We leveraged Large Language Models (LLMs) and developed a language guided scene-level conditional diffusion model for language-controllable, realistic traffic generation.</p>
             </td>
           </tr>
 


### PR DESCRIPTION
## Summary
- fix misspelling of 'Large Language Models'

## Testing
- `grep -R Langauge -n ..`

------
https://chatgpt.com/codex/tasks/task_e_687effaf54c08324874bc304781a32e2